### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,13 @@
       }
     },
     "require": {
-        "hhvm": "^4.102",
+        "hhvm": "^4.128",
         "hhvm/hhast": "^4.78",
-        "hhvm/hsl": "^4.41",
-        "hhvm/hhvm-autoload": "^3.0",
         "facebook/hh-clilib": "^2.5.0rc1",
         "facebook/xhp-lib": "^4.0"
+    },
+    "require-dev": {    
+        "hhvm/hhvm-autoload": "^3.0"
     },
     "config": {
         "allow-plugins": {

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -2,5 +2,6 @@
   "roots": [
     "src/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/src/InspectorCLI.hack
+++ b/src/InspectorCLI.hack
@@ -107,21 +107,21 @@ final class InspectorCLI extends CLIWithRequiredArguments {
 
     switch ($os) {
       case OSFamily::MACOS:
-        $result = \pcntl_exec('/usr/bin/open', varray[$filename], $env);
+        $result = \pcntl_exec('/usr/bin/open', vec[$filename], $env);
         break;
       case OSFamily::LINUX:
         $error_reporting = \error_reporting(0);
         try {
           $result = \pcntl_exec(
             '/usr/bin/sensible-browser',
-            varray[$filename],
+            vec[$filename],
             $env,
           );
         } finally {
           \error_reporting($error_reporting);
         }
         if ($result === false) {
-          $result = \pcntl_exec('/usr/bin/xdg-open', varray[$filename], $env);
+          $result = \pcntl_exec('/usr/bin/xdg-open', vec[$filename], $env);
         }
         break;
       default:


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.
All legacy arrays have been replaced with Hack arrays.